### PR TITLE
allow absolute filenames

### DIFF
--- a/R/insertPackage.R
+++ b/R/insertPackage.R
@@ -54,7 +54,8 @@ insertPackage <- function(file,
     if (!file.exists(srcdir)) stop("Directory ", srcdir, " not found\n", .Call=FALSE)
 
     ## copy file into repo
-    file.copy(file.path(curwd, file), srcdir, overwrite=TRUE)
+		stopifnot(file.copy(file.path(curwd, file), srcdir, overwrite=TRUE) || 
+							file.copy(file, srcdir, overwrite=TRUE))
 
     ## update index
     write_PACKAGES(srcdir, type="source")

--- a/R/insertPackage.R
+++ b/R/insertPackage.R
@@ -76,7 +76,7 @@ insertPackage <- function(file,
             setwd(srcdir)
             cmd <- sprintf(paste("git add %s PACKAGES PACKAGES.gz;",
                                  "git commit -m\"adding %s to drat\";",
-                                 "git push"), package_tgz, package_tgz)
+                                 "git push"), file, package_tgz)
             system(cmd) ## TODO: error checking
         } else {
             warning("Commit skipped as both git2r package and git command missing.",

--- a/R/insertPackage.R
+++ b/R/insertPackage.R
@@ -61,20 +61,22 @@ insertPackage <- function(file,
     write_PACKAGES(srcdir, type="source")
     ## TODO: generalize to binary
 
+		package_tgz <- basename(file)
+
     if (commit) {
         if (haspkg) {
             repo <- git2r::repository(repodir)
             setwd(srcdir)
-            git2r::add(repo, file.path("src", "contrib", file))
+            git2r::add(repo, file.path("src", "contrib", package_tgz))
             git2r::add(repo, file.path("src", "contrib", "PACKAGES"))
             git2r::add(repo, file.path("src", "contrib", "PACKAGES.gz"))
-            git2r::commit(repo, paste("adding", file, "to drat"))
+            git2r::commit(repo, paste("adding", package_tgz, "to drat"))
             # git2r::push(repo)
         } else if (hascmd) {
             setwd(srcdir)
             cmd <- sprintf(paste("git add %s PACKAGES PACKAGES.gz;",
                                  "git commit -m\"adding %s to drat\";",
-                                 "git push"), file, file)
+                                 "git push"), package_tgz, package_tgz)
             system(cmd) ## TODO: error checking
         } else {
             warning("Commit skipped as both git2r package and git command missing.",


### PR DESCRIPTION
Attempts to copy to curwd/file, then to file. Fixes #7.