### PR TITLE
Make it clearer how to change the repo path

### DIFF
--- a/R/insertPackage.R
+++ b/R/insertPackage.R
@@ -38,7 +38,12 @@ insertPackage <- function(file,
     if (!file.exists(file)) stop("File ", file, " not found\n", .Call=FALSE)
     
     ## TODO: make src/contrib if needed
-    if (!file.exists(repodir)) stop("Directory ", repodir, " not found\n", .Call=FALSE)
+    if (!file.exists(repodir)) {
+        stop("Repository directory ", repodir, " not found\n",
+             "You can either set the 'repodir' parameter ('insertPackage(..., repodir=\"/path/to/dratrepo/\")')\n",
+             "or use 'option(dratRepo = \"/path/to/dratrepo/\")' to set one as a default.\n",
+             .Call=FALSE)
+    }
 
     ## check for the optional git2r package
     haspkg <- requireNamespace("git2r", quietly=TRUE)


### PR DESCRIPTION
As this is probably the first comamnd tried by a new users, and
in most occasion this will fail due to missing `~/git/drat`, make
it clear what to do to get it working.