### PR TITLE
insertPackages with commit=TRUE sholdn't error if package is already inserted

### DIFF
--- a/R/insertPackage.R
+++ b/R/insertPackage.R
@@ -94,7 +94,7 @@ insertPackage <- function(file,
             git2r::add(repo, file.path(reldir, pkg))
             git2r::add(repo, file.path(reldir, "PACKAGES"))
             git2r::add(repo, file.path(reldir, "PACKAGES.gz"))
-            git2r::commit(repo, msg)
+            tryCatch(git2r::commit(repo, msg), error = function(e) warning(e))
             #TODO: authentication woes?   git2r::push(repo)  
             message("Added and committed ", pkg, " plus PACKAGES files. Still need to push.\n") 
         } else if (hascmd) {


### PR DESCRIPTION
I think a warning would be better in this case.  An error is rather a nuisance when looping over a bunch of packages to add them, some of which may not have changed.

The error is caused by the `git2r::commit` command, which decides to throw an error if there are no changes to the repository.  I think `drat` should catch this error explicitly and turn it into a warning (or maybe ignore it?)  That would better match the behavior of the command-line mode when git2r isn't available too. 