### PR TITLE
avoid rebuild of the R package in deploy.sh

### DIFF
--- a/vignettes/CombiningDratAndTravis.Rmd
+++ b/vignettes/CombiningDratAndTravis.Rmd
@@ -82,6 +82,8 @@ is found at the end of this vignette and also in the
 #!/bin/bash
 set -o errexit -o nounset
 addToDrat(){
+  PKG_REPO=$PWD
+
   cd ..; mkdir drat; cd drat
 
   ## Set up Repo parameters
@@ -95,7 +97,7 @@ addToDrat(){
   git fetch upstream
   git checkout gh-pages
 
-  Rscript -e "drat::insertPackage(devtools::build('../PKG_NAME'), \
+  Rscript -e "drat::insertPackage('$PKG_REPO/$PKG_TARBALL', \
     repodir = '.', \
     commit='Travis update: build $TRAVIS_BUILD_NUMBER')"
   git push

--- a/vignettes/CombiningDratAndTravis.html
+++ b/vignettes/CombiningDratAndTravis.html
@@ -73,6 +73,8 @@ to your <code>.travis.yml</code> file. This means your <code>drat</code> reposit
 <pre><code>#!/bin/bash
 set -o errexit -o nounset
 addToDrat(){
+  PKG_REPO=$PWD
+
   cd ..; mkdir drat; cd drat
 
   ## Set up Repo parameters
@@ -86,7 +88,7 @@ addToDrat(){
   git fetch upstream
   git checkout gh-pages
 
-  Rscript -e &quot;drat::insertPackage(devtools::build('../PKG_NAME'), \
+  Rscript -e &quot;drat::insertPackage('$PKG_REPO/$PKG_TARBALL', \
     repodir = '.', \
     commit='Travis update: build $TRAVIS_BUILD_NUMBER')&quot;
   git push


### PR DESCRIPTION
Dear Dirk,

thanks for the great `drat` package.

In the current version of the vignette *Combining Drat and Travis CI* the example script `deploy.sh` forces a rebuild of the R package. This PR uses the previous built package and avoids the additional build process.

Best wishes,

Sebastian