### PR TITLE
Add a getPathForMac() function to determine the type of mac package.

### DIFF
--- a/R/insertPackage.R
+++ b/R/insertPackage.R
@@ -68,7 +68,7 @@ insertPackage <- function(file,
     }
 
     pkgtype <- identifyPackageType(file)
-    reldir <- getPathForPackageType(pkgtype)
+    reldir <- getPathForPackageType(pkgtype, file=file)
 
     pkgdir <- file.path(repodir, reldir)
 
@@ -145,12 +145,13 @@ identifyPackageType <- function(file) {
 ##' @title Get relative path for package type
 ##' @param pkgtype The package type as a string.
 ##' @param rversion String which identifies the major.minor 
-### R version, which was used to build this package. Defaults 
+##' R version, which was used to build this package. Defaults 
 ##' to the version of the current interpreter.
+##' @param file the fully qualified path of the package
 ##' @return string Relative file path where packages of 
 ##' this type should be copied to.
 ##' @author Jan Schulz and Dirk Eddelbuettel
-getPathForPackageType <- function(pkgtype, rversion) {
+getPathForPackageType <- function(pkgtype, rversion, file) {
     .getRVersionString <- function() {
         paste(getRversion()$major, getRversion()$minor, sep=".")
         ## or:    gsub("\\.\\d+$", "", getRversion())
@@ -162,7 +163,50 @@ getPathForPackageType <- function(pkgtype, rversion) {
     } else if (pkgtype == "win.binary") {
         file.path("bin", "windows", "contrib", rversion)
     } else if (pkgtype == "mac.binary") {
-        file.path("bin", "macosx", "contrib", rversion)
+        getPathForMac(rversion, file)
     }
     return(ret)
 }
+
+##' This function parses the Built metadata from DESCRIPTION
+##' in a package submission to determine the MacOS path for
+##' binary builds.
+##'
+##' @title Extract R version and built architecture from package DESCRIPTION
+##' @param rversion String which identifies the major.minor 
+##' R version, which was used to build this package. Defaults 
+##' to the version of the current interpreter.
+##' @param file The fully qualified path to the package archive file
+##' @return string Relative file path where packages of 
+##' this type should be copied to.
+##' @author Matthew Jones
+getPathForMac <- function(rversion, file) {
+    if (!file.exists(file)) stop("File ", file, " not found\n", call.=FALSE)
+    
+    # Untar the package and extract the DESCRIPTION file
+    pkg <- basename(file)
+    pkg_name <- sub("_.*", "", pkg)
+    tf <- tempdir()
+    untar(file, exdir=tf)
+    
+    # Find the BUILT metadata line
+    description <- readLines(file.path(tf, pkg_name, "DESCRIPTION"))
+    built_string <- description[grep("Built:", description)]
+    unlink(file.path(tf, pkg_name), recursive=TRUE)
+    #built_string <- 'Built: R 3.2.0; x86_64-apple-darwin13.4.0; 2015-07-28 01:17:32 UTC; unix'
+    #built_string <- 'Built: R 3.2.0; x86_64-apple-darwin10.8.0; 2015-05-11 23:54:50 UTC; unix'
+    #built_string <- 'Built: R 3.2.1; x86_64-w64-mingw32; 2015-06-30 15:08:30 UTC; windows'
+    
+    # TODO: Extract the built R version from BUILT
+    # built <- strsplit(built_string, ';')
+    # pattern <- "R (.*).."
+    # rversion <- gsub(pattern, "\\1", str_extract(built[[1]][1], pattern)[[1]])
+    
+    # Return the correct package path based on the darwin version
+    if (grepl("darwin13", built_string)) {
+        file.path("bin", "macosx", "mavericks", "contrib", rversion)
+    } else {
+        file.path("bin", "macosx", "contrib", rversion)
+    }
+}
+


### PR DESCRIPTION
This function untars the tgz file, extracts the Built: line from the description, and determines if the build platform was "darwin13", in which case "mavericks" is included on the returned path.  Should satisfy #20.

While the package parsing seems to work and I tested it on several package files, I was unsure if you want to check in package files to add to the repo for testing.  If so I could add some tests that check the parsing functions.

Also, its unclear if write_PACKAGES() knows how to deal with the package metadata.  Seems like maybe not, but I don't have any experience with that.