### PR TITLE
Added option to pull remote repo before inserting a package

### DIFF
--- a/R/insertPackage.R
+++ b/R/insertPackage.R
@@ -72,7 +72,7 @@ insertPackage <- function(file,
     
     if (commit && haspkg) {  
         repo <- git2r::repository(repodir)
-        if (pullfirst) git2r::pull(repo)
+        if (isTRUE(pullfirst)) git2r::pull(repo)
         git2r::checkout(repo, "gh-pages")
     } else if (commit && hascmd) {
         setwd(repodir)

--- a/R/insertPackage.R
+++ b/R/insertPackage.R
@@ -25,6 +25,7 @@
 ##' \sQuote{add}, \sQuote{commit}, and \sQuote{push} or, alternatively,
 ##' a character variable can be used to specify a commit message; this also
 ##' implies the \sQuote{TRUE} values in other contexts.
+##' @param pullfirst Boolean toggle to call \code{git pull} before inserting the package. 
 ##' @param action A character string containing one of: \dQuote{none} 
 ##' (the default; add the new package into the repo, effectively masking 
 ##' previous versions), \dQuote{archive} (place any previous versions into 
@@ -46,6 +47,7 @@
 insertPackage <- function(file,
                           repodir=getOption("dratRepo", "~/git/drat"),
                           commit=FALSE,
+                          pullfirst=FALSE,
                           action=c("none", "archive", "prune")) {
 
     if (!file.exists(file)) stop("File ", file, " not found\n", call.=FALSE)
@@ -70,9 +72,11 @@ insertPackage <- function(file,
     
     if (commit && haspkg) {  
         repo <- git2r::repository(repodir)
+        if (pullfirst) git2r::pull(repo)
         git2r::checkout(repo, "gh-pages")
     } else if (commit && hascmd) {
         setwd(repodir)
+        if (isTRUE(pullfirst)) system("git pull")
         system("git checkout gh-pages")
         setwd(curwd)
     }

--- a/man/insertPackage.Rd
+++ b/man/insertPackage.Rd
@@ -7,7 +7,8 @@
 \title{Insert a package source or binary file into a drat repository}
 \usage{
 insertPackage(file, repodir = getOption("dratRepo", "~/git/drat"),
-  commit = FALSE, action = c("none", "archive", "prune"))
+  commit = FALSE, pullfirst = FALSE, action = c("none", "archive",
+  "prune"))
 
 insert(...)
 }
@@ -21,6 +22,8 @@ top-level directory.}
 \sQuote{add}, \sQuote{commit}, and \sQuote{push} or, alternatively,
 a character variable can be used to specify a commit message; this also
 implies the \sQuote{TRUE} values in other contexts.}
+
+\item{pullfirst}{Boolean toggle to call \code{git pull} before inserting the package.}
 
 \item{action}{A character string containing one of: \dQuote{none}
 (the default; add the new package into the repo, effectively masking


### PR DESCRIPTION
Hi Dirk,

I had to re-clone my drat repo several times because I keep forgetting to pull the remote repo before inserting a package. So I thought it would be handy if `drat::insertPackage` pulls the remote repo before committing. 

I added an option `pullfirst` with default `FALSE` so all should behave backwards compatible.

Don't merge it if you don't think its useful.

Cheers,
Mark