### PR TITLE
fix for support dots, solves #39

### DIFF
--- a/R/insertPackage.R
+++ b/R/insertPackage.R
@@ -184,7 +184,7 @@ getPackageInfo <- function(file) {
         return(fields)
     }
 
-    pkgname <- gsub("^([a-zA-Z0-9]*)_.*", "\\1", basename(file))
+    pkgname <- gsub("^([a-zA-Z0-9.]*)_.*", "\\1", basename(file))
     path <- file.path(td, pkgname, "DESCRIPTION")
     builtstring <- read.dcf(path, 'Built')
     unlink(file.path(td, pkgname), recursive=TRUE)


### PR DESCRIPTION
tested on `data.table_1.9.6.zip` file.
I could add tests for that fix but I would need to keep `drat_1.0.0.zip` locally in `inst`.