### PR TITLE
Point to secure github repo.

### DIFF
--- a/R/addRepo.R
+++ b/R/addRepo.R
@@ -39,7 +39,7 @@ addRepo <- function(account, alturl) {
     r <- getOption("repos")
     if (!missing(account) && missing(alturl)) {
         for (acct in account) {
-            r[acct] <- paste0("http://", acct, ".github.io/drat/")
+            r[acct] <- paste0("https://", acct, ".github.io/drat/")
         }
     } else if (!missing(account) && !missing(alturl)) {
         if (.Platform$OS.type == "windows") {


### PR DESCRIPTION
The drat repo supports https. Since CRAN is https, makes sense to switch. 