### PR TITLE
Put 3.3 mac binaries in mavericks, 3.4 in el-capitan

### DIFF
--- a/R/insertPackage.R
+++ b/R/insertPackage.R
@@ -229,7 +229,11 @@ getPathForPackage <- function(file) {
     } else if (pkgtype == "mac.binary") {
         if (unname(fields["OSflavour"]) == "") {
             # non-binary package, treated as el-capitan
-            fields["osxFolder"] <- "el-capitan"
+            if(grepl("mac.binary", .Platform$pkgType)) {
+              fields["osxFolder"] <- gsub("mac.binary.", "", .Platform$pkgType)
+            } else {
+              fields["osxFolder"] <- "el-capitan"
+            }
             message("Note: Non-binary OS X package will be installed in ", fields["osxFolder"], " path.")
         }
         if (unname(fields["osxFolder"]) != "") {


### PR DESCRIPTION
This is a partial solution to #64 - enough to get our travis builds to put mac binaries in the correct folders. There doesn't seem like a good way to tell which folder (mavericks/el-capitan) a mac non-compiled package goes in, so I'm defaulting to the version of R running drat in that case. 