### PR TITLE
WIP - Adding git2r credentials option.

### DIFF
--- a/R/insertPackage.R
+++ b/R/insertPackage.R
@@ -24,6 +24,7 @@
 ##' \describe{
 ##'   \item{\code{dratRepo}}{Path to git repo. Defaults to \code{~/git/drat}}
 ##'   \item{\code{dratBranch}}{The git branch to store packages on. Defaults to \code{gh-pages}}
+##'   \item{\code{dratCreds}}{A \code{git2r} credentials object. Not used via command mode.}
 ##' }
 ##'
 ##' @title Insert a package source or binary file into a drat repository
@@ -122,7 +123,7 @@ insertPackage <- function(file,
             git2r::add(repo, file.path(reldir, "PACKAGES.gz"))
             git2r::add(repo, file.path(reldir, "PACKAGES.rds"))
             tryCatch(git2r::commit(repo, msg), error = function(e) warning(e))
-            #TODO: authentication woes?   git2r::push(repo)
+            git2r::push(repo, credentials=getOption("dratCreds"))
             message("Added and committed ", pkg, " plus PACKAGES files. Still need to push.\n")
         } else if (hascmd) {
             setwd(pkgdir)


### PR DESCRIPTION
Thanks for pushing the new version of drat over the weekend.

While I'm in here, fixing an old `todo`,  but needs to be tested. It might make sense to move the push inside the precending `tryCatch` - if the commit fails there isn't any reason to push. I will be using this with `cred_token` in our travis builds but I think it will work with the other credential types (SSH, plain text, ...).