### PR TITLE
Setting working dir correctly for git2r commits

### DIFF
--- a/R/insertPackage.R
+++ b/R/insertPackage.R
@@ -96,7 +96,7 @@ insertPackage <- function(file,
     pkgtype <- identifyPackageType(file)
     reldir <- getPathForPackage(file)
 
-    pkgdir <- file.path(repodir, reldir)
+    pkgdir <- normalizePath(file.path(repodir, reldir))
 
     if (!file.exists(pkgdir)) {
         ## TODO: this could be in a git branch, need checking
@@ -116,7 +116,7 @@ insertPackage <- function(file,
     if (commit) {
         if (haspkg) {
             repo <- git2r::repository(repodir)
-            setwd(pkgdir)
+            setwd(repodir)
             git2r::add(repo, file.path(reldir, pkg))
             git2r::add(repo, file.path(reldir, "PACKAGES"))
             git2r::add(repo, file.path(reldir, "PACKAGES.gz"))

--- a/R/insertPackage.R
+++ b/R/insertPackage.R
@@ -116,11 +116,11 @@ insertPackage <- function(file,
     if (commit) {
         if (haspkg) {
             repo <- git2r::repository(repodir)
-            setwd(repodir)
-            git2r::add(repo, file.path(reldir, pkg))
-            git2r::add(repo, file.path(reldir, "PACKAGES"))
-            git2r::add(repo, file.path(reldir, "PACKAGES.gz"))
-            git2r::add(repo, file.path(reldir, "PACKAGES.rds"))
+            setwd(pkgdir)
+            git2r::add(repo, pkg)
+            git2r::add(repo, "PACKAGES")
+            git2r::add(repo, "PACKAGES.gz")
+            git2r::add(repo, "PACKAGES.rds")
             tryCatch(git2r::commit(repo, msg), error = function(e) warning(e))
             #TODO: authentication woes?   git2r::push(repo)
             message("Added and committed ", pkg, " plus PACKAGES files. Still need to push.\n")

--- a/tests/skeleton_git2r.R
+++ b/tests/skeleton_git2r.R
@@ -1,0 +1,39 @@
+
+testSkeletonGit2r <- function() {
+  if(!requireNamespace("git2r")) return(warning("couldn't find git2r"))
+  
+  wd <- tempdir()
+  
+  # options(error=traceback)
+  
+  # make a package to test with
+  .foofn <- function() "foo"
+  utils::package.skeleton(name = "foo", list=".foofn", environment = environment(), path=wd)
+  print(dir(wd, recursive = TRUE))
+
+  message("building")
+  
+  #https://github.com/r-lib/testthat/issues/129
+  R_TESTS=Sys.getenv("R_TESTS")
+  Sys.setenv(R_TESTS="")
+  system(sprintf("R CMD build %s --no-manual", file.path(wd, "foo")))
+  Sys.setenv(R_TESTS=R_TESTS)
+  message("dratting")
+  
+  # make a repo to test with
+  rdir <- file.path(wd, "drat")
+  
+  dir.create(rdir)
+  repo <- git2r::init(rdir)
+  git2r::config(repo, user.name="Alice", user.email="alice@example.org")
+  cat("foo", file=file.path(rdir, "README"))
+  git2r::add(repo, "README")
+  comm <- git2r::commit(repo, "init")
+  git2r::branch_create(comm,"gh-pages")
+
+  # finally add the package
+  drat::insertPackage(file = "foo_1.0.tar.gz", repodir = rdir, commit = "test")
+  list(git2r::status(repo), dir(rdir, recursive = TRUE))
+}
+
+testSkeletonGit2r()

--- a/tests/skeleton_git2r.R
+++ b/tests/skeleton_git2r.R
@@ -16,7 +16,10 @@ testSkeletonGit2r <- function() {
   #https://github.com/r-lib/testthat/issues/129
   R_TESTS=Sys.getenv("R_TESTS")
   Sys.setenv(R_TESTS="")
-  system(sprintf("R CMD build %s --no-manual", file.path(wd, "foo")))
+  cwd <- getwd()
+  setwd(wd)
+  system("R CMD build foo --no-manual")
+  setwd(cwd)
   Sys.setenv(R_TESTS=R_TESTS)
   message("dratting")
   
@@ -32,7 +35,7 @@ testSkeletonGit2r <- function() {
   git2r::branch_create(comm,"gh-pages")
 
   # finally add the package
-  drat::insertPackage(file = "foo_1.0.tar.gz", repodir = rdir, commit = "test")
+  drat::insertPackage(file = file.path(wd, "foo_1.0.tar.gz"), repodir = rdir, commit = "test")
   list(git2r::status(repo), dir(rdir, recursive = TRUE))
 }
 


### PR DESCRIPTION
Hi Dirk, I'm trying to get appveyor to push windows zips for DeclareDesign, we had been getting clean builds but containing

```
Added and committed randomizr_0.7.0.zip plus PACKAGES files. Still need to push.
Warning message:
In git2r::commit(repo, msg) :
  Error in 'git2r_commit': Nothing added to commit
```
at then end - (I had't caught this before christmas because many of our changes to master at that time were for pkgdown websites, which trigger builds but the .zip doesn't change and git would correctly not record a change).

Anyway, I spent some time debugging, and finally noticed that on the git2r side, we both `setwd()` to 'bin/windows/contrib/3.4' and then also `add(repo, "bin/windows/contrib/3.4/randomizr_0.8.0.zip")`, so git2r::add tries to normalize the path and ultimately add `bin/windows/contrib/3.4/bin/windows/contrib/3.4/randomizr_0.8.0.zip`

Unclear to me why this is broken for appveyor/windows and not for travis/linux, but changing the two lines in this PR seems to fix it. Probably git2r has changed since these lines were written ?

