### PR TITLE
bugfix for adding the newest package again, while selecting "archive"…

### DIFF
--- a/R/archivePackages.R
+++ b/R/archivePackages.R
@@ -94,7 +94,9 @@ archivePackages <- function(repopath = getOption("dratRepo", "~/git/drat"),
     mapply(.move_to_archive_directory, repoinfo$contrib.url, repoinfo$package,
            repoinfo$file)
     # update 
-    updateRepo(repopath, type = unique(repoinfo$type), version = version)
+    if(nrow(repoinfo) >= 1L){
+        updateRepo(repopath, type = unique(repoinfo$type), version = version)
+    }
     invisible(NULL)
 }
 

--- a/R/pruneRepo.R
+++ b/R/pruneRepo.R
@@ -154,9 +154,8 @@ pruneRepo <- function(repopath = getOption("dratRepo", "~/git/drat"),
     #
     repoinfo <- getRepoInfo(repopath = repopath, type = type, pkg = pkg,
                             version = version)
-    if (remove != FALSE) {
-        #
-        rmfiles <- repoinfo[!repoinfo[,"newest"],]
+    rmfiles <- repoinfo[!repoinfo[,"newest"],]
+    if (remove != FALSE && nrow(rmfiles) >= 1L) {
         if (remove == "git") {
             haspkg <- requireNamespace("git2r", quietly = TRUE)
             if (!haspkg)

--- a/tests/skeleton_git2r.R
+++ b/tests/skeleton_git2r.R
@@ -96,6 +96,8 @@ testRepoActions <- function(repodir){
     stop("Wrong package files found")
   }
   #
+  repoinfo <- drat::pruneRepo(repopath = repodir, remove = TRUE)
+  #
   repoinfo <- drat:::getRepoInfo(repopath = repodir, version = NA)
   if(nrow(repoinfo) != 6L){
     stop("Wrong package files found")

--- a/tests/skeleton_git2r.R
+++ b/tests/skeleton_git2r.R
@@ -115,6 +115,7 @@ testRepoActions <- function(repodir){
             "bin/macosx/el-capitan/contrib/3.6", "src/contrib/Archive/foo") %in% res$dir)){
     stop("Wrong dir structure")
   }
+  drat::insertPackages(file = src_files[3], repodir = repodir, action="archive")
   #
   drat::archivePackages(repopath = repodir, type = "binary", version = "3.6")
   res <- list(dir = unique(dirname(dir(repodir, recursive = TRUE))))


### PR DESCRIPTION
… as action

zero number of packages are removed in this case and updateRepo throws an error as expected.

This escaped my tests and I stumbled upon it by accident. test for this is added as well.