### PR TITLE
fixed issue for pruning on R 3.6

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2020-07-17  FelixErnst  <felix.gm.ernst@outlook.com>
+
+	* tests/skeleton_get2r.R: Fixed issue for pruning on r-oldrel
+	
 2020-07-10  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version): Release 0.1.7

--- a/tests/skeleton_git2r.R
+++ b/tests/skeleton_git2r.R
@@ -96,9 +96,16 @@ testRepoActions <- function(repodir){
   #
   repoinfo <- drat::pruneRepo(repopath = repodir, remove = TRUE)
   #
-  repoinfo <- drat:::getRepoInfo(repopath = repodir, version = NA)
-  if(nrow(repoinfo) != 6L){
-    stop("Wrong package files found after pruning for version = NA")
+  repoinfo <- drat:::getRepoInfo(repopath = repodir, version = NA,
+                                 type = c("source","binary"))
+  if(getRversion() < package_version("4.0")){
+    if(nrow(repoinfo) != 4L){
+      stop("Wrong package files found after pruning for version = NA")
+    }
+  } else {
+    if(nrow(repoinfo) != 6L){
+      stop("Wrong package files found after pruning for version = NA")
+    }
   }
   repoinfo2 <- drat::pruneRepoForAllRversions(repopath = repodir, remove = TRUE)
   if(nrow(repoinfo2) != 4L){


### PR DESCRIPTION
Due to the automatic detection of the version pruning does have a result based on R version used. The test scenario changed is covert in R 3.6 by an earlier call, which is now fixed by testing with a condition.