### PR TITLE
Support docs/ directory as alternative to gh-pages branch

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 2021-03-13  Dirk Eddelbuettel  <edd@debian.org>
 
+ 	* DESCRIPTION (Version, Date): Roll minor version
+
 	* R/initRepo.R (initRepo): New option location to allow use of docs/
 	directory instead of gh-pages branch
 	* R/insertPackage.R (insertPackage): Ditto

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,9 @@
 
 	* R/initRepo.R (initRepo): New option location to allow use of docs/
 	directory instead of gh-pages branch
+	* R/insertPackage.R (insertPackage): Ditto
+	* man/initRepo.Rd: Documentation for new location option
+	* man/insertPackage.Rd: Ditto
 
 2021-02-24  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2021-03-13  Dirk Eddelbuettel  <edd@debian.org>
+
+	* R/initRepo.R (initRepo): New option location to allow use of docs/
+	directory instead of gh-pages branch
+
 2021-02-24  Dirk Eddelbuettel  <edd@debian.org>
 
 	* docs-src/mkdocs.yml: No longer show vignette overview

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: drat
 Type: Package
 Title: 'Drat' R Archive Template
-Version: 0.1.8
-Date: 2020-07-18
+Version: 0.1.8.1
+Date: 2021-03-13
 Author: Dirk Eddelbuettel with contributions by Carl Boettiger, Neal Fultz,
  Sebastian Gibb, Colin Gillespie, Jan Górecki, Matt Jones, Thomas Leeper,
  Steven Pav, Jan Schulz, Christoph Stepper, Felix G.M. Ernst and Patrick 
@@ -21,4 +21,4 @@ License: GPL (>= 2)
 URL: https://dirk.eddelbuettel.com/code/drat.html
 BugReports: https://github.com/eddelbuettel/drat/issues
 Encoding: UTF-8
-RoxygenNote: 7.1.0
+RoxygenNote: 6.0.1

--- a/R/initRepo.R
+++ b/R/initRepo.R
@@ -20,21 +20,19 @@
 ##' @param location A character variable with the GitHub Pages location:
 ##' either \dQuote{gh-pages} indicating a branch of that name, or
 ##' \dQuote{docs/} directory in the main branch. The default value can
-##' be overridden via the \dQuote{dratGHPages} option.
+##' be overridden via the \dQuote{dratBranch} option.
 ##' @return The function is invoked for its side-effects and only
 ##' returns \code{NULL} invisibly.
 ##' @author Dirk Eddelbuettel
-initRepo <- function(name="drat",
-                     basepath=getOption("dratDirectory", "~/git"),
-                     location=getOption("dratGHPages", "gh-pages")) {
+initRepo <- function(name = "drat",
+                     basepath = getOption("dratDirectory", "~/git"),
+                     location = getOption("dratBranch", "gh-pages")) {
 
     haspkg <- requireNamespace("git2r", quietly=TRUE)
-    if (!haspkg)
-        stop("The 'initRepo' function requires the 'git2r' packages.", call.=FALSE)
+    if (!haspkg) stop("The 'initRepo' function requires the 'git2r' packages.", call.=FALSE)
     
     dir <- file.path(basepath, name)
-    if (file.exists(dir))
-        stop("Directory '", dir, "' already exists.", call.=FALSE)
+    if (file.exists(dir)) stop("Directory '", dir, "' already exists.", call.=FALSE)
 
     if (is.na(match(location, c("gh-pages", "docs"))))
         stop("Location argument unsuitable.", call.=FALSE)

--- a/R/initRepo.R
+++ b/R/initRepo.R
@@ -1,9 +1,12 @@
 
-##' This helper function create a new repository, creates and checks
-##' out \sQuote{gh-pages} branch and fills it with the required path.
+##' This helper function creates a new repository, creates and checks
+##' out the default GitHub Pages location (either the \sQuote{gh-pages}
+##' branch or directory \sQuote{docs}) and fills it with the required
+##' new paths.
 ##' 
 ##' Currently only \sQuote{src/contrib} for source repositories is
-##' supported.
+##' supported by this function. The \code{insertPackage()} function knows
+##' to deal with binaries for different architectures.
 ##'
 ##' This function is still undergoing development and polish and may
 ##' change in subsequent versions.
@@ -13,17 +16,28 @@
 ##' the default is \dQuote{drat}.
 ##' @param basepath A character variable with path to the directory in
 ##' which the new repository is to be created. The default value is
-##' \dQuote{"~/git"}.
+##' \dQuote{~/git} and can be overriden via option \sQuote{dratDirectory}.
+##' @param location A character variable with the GitHub Pages location:
+##' either \dQuote{gh-pages} indicating a branch of that name, or
+##' \dQuote{docs/} directory in the main branch. The default value can
+##' be overridden via the \dQuote{dratGHPages} option.
 ##' @return The function is invoked for its side-effects and only
 ##' returns \code{NULL} invisibly.
 ##' @author Dirk Eddelbuettel
-initRepo <- function(name="drat", basepath="~/git") {
+initRepo <- function(name="drat",
+                     basepath=getOption("dratDirectory", "~/git"),
+                     location=getOption("dratGHPages", "gh-pages")) {
 
     haspkg <- requireNamespace("git2r", quietly=TRUE)
-    if (!haspkg) stop("The 'initRepo' function requires the 'git2r' packages.", call.=FALSE)
+    if (!haspkg)
+        stop("The 'initRepo' function requires the 'git2r' packages.", call.=FALSE)
     
     dir <- file.path(basepath, name)
-    if (file.exists(dir)) stop("Directory '", dir, "' already exists.", call.=FALSE)
+    if (file.exists(dir))
+        stop("Directory '", dir, "' already exists.", call.=FALSE)
+
+    if (is.na(match(location, c("gh-pages", "docs"))))
+        stop("Location argument unsuitable.", call.=FALSE)
 
     dir.create(dir)
     repo <- git2r::init(dir)
@@ -32,8 +46,13 @@ initRepo <- function(name="drat", basepath="~/git") {
     git2r::add(repo, "README.md")
     cmt <- git2r::commit(repo, "Initial Commit")
 
-    git2r::checkout(repo, "gh-pages", create=TRUE)
-    
+    if (location == "gh-pages") {
+        git2r::checkout(repo, "gh-pages", create=TRUE)
+    } else if (location == "docs") {
+        dir <- file.path(dir, location)
+        dir.create(dir)
+    }
+
     dir.create(file.path(dir, "src"))
     dir.create(file.path(dir, "src", "contrib"))
     ## create binary path as well ?

--- a/R/insertPackage.R
+++ b/R/insertPackage.R
@@ -98,16 +98,12 @@ insertPackage <- function(file,
         if (isTRUE(pullfirst)) git2r::pull(repo)
         if (branch == "gh-pages") {
             git2r::checkout(repo, branch)
-        } else {
-            setwd(branch)
         }
     } else if (commit && hascmd) {
         setwd(repodir)
         if (isTRUE(pullfirst)) system("git pull")
         if (branch == "gh-pages") {
             system2("git", c("checkout", branch))
-            setwd(curwd)
-        } else {
             setwd(curwd)
         }
     }
@@ -124,7 +120,6 @@ insertPackage <- function(file,
             stop("Directory ", pkgdir, " couldn't be created\n", call. = FALSE)
         }
     }
-
     ## copy file into repo
     if (!file.copy(file, pkgdir, overwrite = TRUE)) {
         stop("File ", file, " can not be copied to ", pkgdir, call. = FALSE)

--- a/man/addRepo.Rd
+++ b/man/addRepo.Rd
@@ -41,7 +41,6 @@ This function retrieves the current set of repositories (see
 non-GitHub repositories an alternative URL can be specified as
 \sQuote{alturl} (and assigned to \sQuote{account} as well).
 
-
 An aliased function \code{add} is also available, but not exported
 via \code{NAMESPACE} to not clobber a possibly unrelated function;
 use it via \code{drat:::add()}.

--- a/man/archivePackages.Rd
+++ b/man/archivePackages.Rd
@@ -2,23 +2,17 @@
 % Please edit documentation in R/archivePackages.R
 \name{archivePackages}
 \alias{archivePackages}
+\alias{archivePackages}
 \alias{archivePackagesForAllRversions}
 \title{Move older copies of packages to an archive}
 \usage{
-archivePackages(
-  repopath = getOption("dratRepo", "~/git/drat"),
+archivePackages(repopath = getOption("dratRepo", "~/git/drat"),
   type = c("source", "binary", "mac.binary", "mac.binary.el-capitan",
-    "mac.binary.mavericks", "win.binary", "both"),
-  pkg,
-  version = getRversion()
-)
+  "mac.binary.mavericks", "win.binary", "both"), pkg, version = getRversion())
 
-archivePackagesForAllRversions(
-  repopath = getOption("dratRepo", "~/git/drat"),
+archivePackagesForAllRversions(repopath = getOption("dratRepo", "~/git/drat"),
   type = c("source", "binary", "mac.binary", "mac.binary.el-capitan",
-    "mac.binary.mavericks", "win.binary", "both"),
-  pkg
-)
+  "mac.binary.mavericks", "win.binary", "both"), pkg)
 }
 \arguments{
 \item{repopath}{Character variable with the path to the repo;

--- a/man/initRepo.Rd
+++ b/man/initRepo.Rd
@@ -4,7 +4,8 @@
 \alias{initRepo}
 \title{Intialize a git repo for drat}
 \usage{
-initRepo(name = "drat", basepath = "~/git")
+initRepo(name = "drat", basepath = getOption("dratDirectory", "~/git"),
+  location = getOption("dratGHPages", "gh-pages"))
 }
 \arguments{
 \item{name}{A character variable with the name the new repository,
@@ -12,19 +13,27 @@ the default is \dQuote{drat}.}
 
 \item{basepath}{A character variable with path to the directory in
 which the new repository is to be created. The default value is
-\dQuote{"~/git"}.}
+\dQuote{~/git} and can be overriden via option \sQuote{dratDirectory}.}
+
+\item{location}{A character variable with the GitHub Pages location:
+either \dQuote{gh-pages} indicating a branch of that name, or
+\dQuote{docs/} directory in the main branch. The default value can
+be overridden via the \dQuote{dratGHPages} option.}
 }
 \value{
 The function is invoked for its side-effects and only
 returns \code{NULL} invisibly.
 }
 \description{
-This helper function create a new repository, creates and checks
-out \sQuote{gh-pages} branch and fills it with the required path.
+This helper function creates a new repository, creates and checks
+out the default GitHub Pages location (either the \sQuote{gh-pages}
+branch or directory \sQuote{docs}) and fills it with the required
+new paths.
 }
 \details{
 Currently only \sQuote{src/contrib} for source repositories is
-supported.
+supported by this function. The \code{insertPackage()} function knows
+to deal with binaries for different architectures.
 
 This function is still undergoing development and polish and may
 change in subsequent versions.

--- a/man/initRepo.Rd
+++ b/man/initRepo.Rd
@@ -5,7 +5,7 @@
 \title{Intialize a git repo for drat}
 \usage{
 initRepo(name = "drat", basepath = getOption("dratDirectory", "~/git"),
-  location = getOption("dratGHPages", "gh-pages"))
+  location = getOption("dratBranch", "gh-pages"))
 }
 \arguments{
 \item{name}{A character variable with the name the new repository,
@@ -18,7 +18,7 @@ which the new repository is to be created. The default value is
 \item{location}{A character variable with the GitHub Pages location:
 either \dQuote{gh-pages} indicating a branch of that name, or
 \dQuote{docs/} directory in the main branch. The default value can
-be overridden via the \dQuote{dratGHPages} option.}
+be overridden via the \dQuote{dratBranch} option.}
 }
 \value{
 The function is invoked for its side-effects and only

--- a/man/insertPackage.Rd
+++ b/man/insertPackage.Rd
@@ -9,7 +9,7 @@
 \usage{
 insertPackage(file, repodir = getOption("dratRepo", "~/git/drat"),
   commit = FALSE, pullfirst = FALSE, action = c("none", "archive",
-  "prune"), ...)
+  "prune"), location = getOption("dratBranch", "gh-pages"), ...)
 
 insertPackages(file, ...)
 
@@ -33,6 +33,11 @@ implies the \sQuote{TRUE} values in other contexts.}
 previous versions), \dQuote{archive} (place any previous versions into
 a package-specific archive folder, creating such an archive if it does
 not already exist), or \dQuote{prune} (calling \code{\link{pruneRepo}}).}
+
+\item{location}{A character variable with the GitHub Pages location:
+either \dQuote{gh-pages} indicating a branch of that name, or
+\dQuote{docs/} directory in the main branch. The default value can
+be overridden via the \dQuote{dratBranch} option.}
 
 \item{...}{For \code{insert} the aliases variant, a catch-all collection of
 parameters. For \code{insertPackage} arguments passed to 

--- a/man/insertPackage.Rd
+++ b/man/insertPackage.Rd
@@ -7,14 +7,9 @@
 \alias{insert}
 \title{Insert a package source or binary file into a drat repository}
 \usage{
-insertPackage(
-  file,
-  repodir = getOption("dratRepo", "~/git/drat"),
-  commit = FALSE,
-  pullfirst = FALSE,
-  action = c("none", "archive", "prune"),
-  ...
-)
+insertPackage(file, repodir = getOption("dratRepo", "~/git/drat"),
+  commit = FALSE, pullfirst = FALSE, action = c("none", "archive",
+  "prune"), ...)
 
 insertPackages(file, ...)
 

--- a/man/pruneRepo.Rd
+++ b/man/pruneRepo.Rd
@@ -3,42 +3,26 @@
 \name{pruneRepo}
 \alias{pruneRepo}
 \alias{getRepoInfo}
+\alias{pruneRepo}
 \alias{pruneRepoForAllRversions}
 \alias{updateRepo}
 \title{Prune repository from older copies of packages}
 \usage{
-getRepoInfo(
-  repopath = getOption("dratRepo", "~/git/drat"),
+getRepoInfo(repopath = getOption("dratRepo", "~/git/drat"),
   type = c("source", "binary", "mac.binary", "mac.binary.el-capitan",
-    "mac.binary.mavericks", "win.binary", "both"),
-  pkg,
-  version = getRversion()
-)
+  "mac.binary.mavericks", "win.binary", "both"), pkg, version = getRversion())
 
-pruneRepo(
-  repopath = getOption("dratRepo", "~/git/drat"),
-  type = c("source", "mac.binary", "mac.binary.el-capitan", "mac.binary.mavericks",
-    "win.binary", "both"),
-  pkg,
-  version = getRversion(),
-  remove = FALSE
-)
+pruneRepo(repopath = getOption("dratRepo", "~/git/drat"), type = c("source",
+  "mac.binary", "mac.binary.el-capitan", "mac.binary.mavericks", "win.binary",
+  "both"), pkg, version = getRversion(), remove = FALSE)
 
-pruneRepoForAllRversions(
-  repopath = getOption("dratRepo", "~/git/drat"),
-  type = c("source", "mac.binary", "mac.binary.el-capitan", "mac.binary.mavericks",
-    "win.binary", "both"),
-  pkg,
-  remove = FALSE
-)
+pruneRepoForAllRversions(repopath = getOption("dratRepo", "~/git/drat"),
+  type = c("source", "mac.binary", "mac.binary.el-capitan",
+  "mac.binary.mavericks", "win.binary", "both"), pkg, remove = FALSE)
 
-updateRepo(
-  repopath = getOption("dratRepo", "~/git/drat"),
-  type = c("source", "mac.binary", "mac.binary.el-capitan", "mac.binary.mavericks",
-    "win.binary", "both"),
-  version = NA,
-  ...
-)
+updateRepo(repopath = getOption("dratRepo", "~/git/drat"),
+  type = c("source", "mac.binary", "mac.binary.el-capitan",
+  "mac.binary.mavericks", "win.binary", "both"), version = NA, ...)
 }
 \arguments{
 \item{repopath}{Character variable with the path to the repo;


### PR DESCRIPTION
This PR adds support for `docs/` as a location for the drat repo instead of the older gh-pages.

It was tested with a simple script to initialize a repo and then installing a package, both via direct option and via `options()`.

@FelixErnst if by chance you have a few minutes I'd love for you to take a look too as you did the last and very careful rewrite of the package insertion.  It _should_ just flow as we "merely" change to top-level location of where it happens but it very easy to overlook a thing or two.  So far everything is optional, and has to be opted into explicitly.