### PR TITLE
Fix - big-sur ARM OSX : binary packages are not set properly

### DIFF
--- a/R/archivePackages.R
+++ b/R/archivePackages.R
@@ -25,7 +25,7 @@ DRAT_CONTRIB_VERSION_REGEX <- paste0("contrib/",DRAT_VERSION_REGEX)
     }
     if("binary" %in% type){
         type <- c(type,DRAT_BINARY_TYPES)
-        type <- type[type != "binary"]
+        # type <- type[type != "binary"]
         type <- unique(type)
     }
     type

--- a/R/pruneRepo.R
+++ b/R/pruneRepo.R
@@ -89,10 +89,10 @@ getRepoInfo <- function(repopath = getOption("dratRepo", "~/git/drat"),
     ## type == "both" is not supported
     ext <- if (type == "source") {
         "\\.tar\\..*$"
-    } else if (grepl("mac.binary",type)) {
-        "\\.tgz$"
     } else if (type == "win.binary") {
         "\\.zip$"
+    } else if (grepl("binary",type)) {
+        "\\.tgz$"
     } else {
         stop("Unknown package type", call. = FALSE)
     }
@@ -156,7 +156,7 @@ getRepoInfo <- function(repopath = getOption("dratRepo", "~/git/drat"),
 
 ##' @rdname pruneRepo
 pruneRepo <- function(repopath = getOption("dratRepo", "~/git/drat"),
-                      type = c("source", "mac.binary", "mac.binary.el-capitan",
+                      type = c("source", "binary", "mac.binary", "mac.binary.el-capitan",
                                "mac.binary.mavericks", "win.binary", "both"), 
                       pkg,
                       version = getRversion(),


### PR DESCRIPTION
On M1 chip:

```r
> contrib.url(getOption("repos"), "binary")
[1] "https://cran.rstudio.com/bin/macosx/big-sur-arm64/contrib/4.1"
> contrib.url(getOption("repos"), "mac.binary")
[1] "https://cran.rstudio.com/bin/macosx/contrib/4.1"
```

I'm not sure this PR fix is proper. I only tested `insertPackage` but haven't tested on any other cases.
