### PR TITLE
add mac.binary.big-sur-arm64 to type param (closes #134)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2022-09-21 Joey Reid <joey.reid@metrotransit.org>
+
+  * R/pruneRepo.R: Add support for macOS binaries on arm64
+  * R/archivePackages.R: Idem
+  * tests/testArmBinary.R: Idem
+
 2022-04-13  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Release 0.2.3

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,8 @@
   * R/pruneRepo.R: Add support for macOS binaries on arm64
   * R/archivePackages.R: Idem
   * tests/testArmBinary.R: Idem
+  * man/pruneRepo.Rd: Idem
+  * man/archivePackages.Rd: Idem
 
 2022-04-13  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/R/archivePackages.R
+++ b/R/archivePackages.R
@@ -1,9 +1,9 @@
 
 DRAT_ARCHIVE_SUB_DIR <- "Archive"
 
-DRAT_BINARY_TYPES <- c("mac.binary","mac.binary.el-capitan",
+DRAT_BINARY_TYPES <- c("mac.binary", "mac.binary.big-sur-arm64", "mac.binary.el-capitan",
                        "mac.binary.mavericks", "win.binary")
-DRAT_BOTH_TYPES <- c("source", "mac.binary","mac.binary.el-capitan",
+DRAT_BOTH_TYPES <- c("source", "mac.binary", "mac.binary.big-sur-arm64", "mac.binary.el-capitan",
                      "mac.binary.mavericks", "win.binary")
 
 DRAT_VERSION_REGEX <- "[0-9]\\.[0-9]$"
@@ -17,8 +17,8 @@ DRAT_CONTRIB_VERSION_REGEX <- paste0("contrib/",DRAT_VERSION_REGEX)
 }
 
 .norm_type <- function(type){
-    type <- match.arg(type,c("source", "binary", "mac.binary","mac.binary.el-capitan",
-                             "mac.binary.mavericks", "win.binary", "both"), 
+    type <- match.arg(type,c("source", "binary", "mac.binary", "mac.binary.big-sur-arm64", "mac.binary.el-capitan",
+                             "mac.binary.mavericks", "win.binary", "both"),
                       several.ok = TRUE)
     if("both" %in% type){
         return(DRAT_BOTH_TYPES)
@@ -45,9 +45,9 @@ DRAT_CONTRIB_VERSION_REGEX <- paste0("contrib/",DRAT_VERSION_REGEX)
         stop("The 'location' argument '", location, "' is unsuitable.", call. = FALSE)
 }
 
-##' The function moves older versions of packages into a CRAN-style 
+##' The function moves older versions of packages into a CRAN-style
 ##' archive folder.
-##' 
+##'
 ##' This function is still undergoing development and polish and may
 ##' change in subsequent versions.
 ##'
@@ -57,13 +57,14 @@ DRAT_CONTRIB_VERSION_REGEX <- paste0("contrib/",DRAT_VERSION_REGEX)
 ##' defaults to the value of the \dQuote{dratRepo} option with
 ##' \dQuote{"~/git/drat"} as fallback
 ##' @param type Character variable for the type of repository, so far
-##'  \dQuote{source}, \dQuote{binary}, \dQuote{win.binary}, \dQuote{mac.binary}, 
-##'  \dQuote{mac.binary.mavericks}, \dQuote{mac.binary.el-capitan} or 
+##'  \dQuote{source}, \dQuote{binary}, \dQuote{win.binary}, \dQuote{mac.binary},
+##'  \dQuote{mac.binary.big-sur-arm64},
+##'  \dQuote{mac.binary.mavericks}, \dQuote{mac.binary.el-capitan} or
 ##'  \dQuote{both}
 ##' @param pkg Optional character variable specifying a package name(s), whose
-##' older versions should be archived. If missing (the default), archiving is 
+##' older versions should be archived. If missing (the default), archiving is
 ##' performed on all packages.
-##' @param version R version information in the format \code{X.Y} or 
+##' @param version R version information in the format \code{X.Y} or
 ##'   \code{X.Y.Z}. Only used, if archiving binary packages.
 ##'   (default: \code{version = getRversion()}). If \code{version = NA}, all
 ##'   available R versions will be used. If \code{version = NULL}, this defaults
@@ -78,7 +79,7 @@ NULL
 
 ##' @rdname archivePackages
 archivePackages <- function(repopath = getOption("dratRepo", "~/git/drat"),
-                            type = c("source", "binary", "mac.binary", "mac.binary.el-capitan",
+                            type = c("source", "binary", "mac.binary", "mac.binary.big-sur-arm64", "mac.binary.el-capitan",
                                      "mac.binary.mavericks", "win.binary", "both"),
                             pkg,
                             version = getRversion()) {
@@ -98,14 +99,14 @@ archivePackages <- function(repopath = getOption("dratRepo", "~/git/drat"),
     # move each package
     mapply(.move_to_archive_directory, repoinfo$contrib.url, repoinfo$package,
            repoinfo$file)
-    # update 
+    # update
     if(nrow(repoinfo) >= 1L){
         updateRepo(repopath, type = unique(repoinfo$type), version = version)
     }
     invisible(NULL)
 }
 
-# if a repodir exists at a an archive subdirectory to it. Otherwise leave it 
+# if a repodir exists at a an archive subdirectory to it. Otherwise leave it
 # alone
 .prepare_archive_directory <- function(repodir){
     archive <- file.path(repodir, DRAT_ARCHIVE_SUB_DIR)[file.exists(file.path(repodir))]
@@ -139,7 +140,7 @@ archivePackages <- function(repopath = getOption("dratRepo", "~/git/drat"),
 
 ##' @rdname archivePackages
 archivePackagesForAllRversions <- function(repopath = getOption("dratRepo", "~/git/drat"),
-                                           type = c("source", "binary", "mac.binary", "mac.binary.el-capitan",
+                                           type = c("source", "binary", "mac.binary", "mac.binary.big-sur-arm64", "mac.binary.el-capitan",
                                                     "mac.binary.mavericks", "win.binary", "both"),
                                            pkg){
     archivePackages(repopath = repopath, type = type, pkg = pkg, version = NA)

--- a/R/pruneRepo.R
+++ b/R/pruneRepo.R
@@ -6,29 +6,29 @@
 ##' Given a package name, R will always find the newest version of
 ##' that package. Older versions are therefore effectively shadowed
 ##' and can be removed without functionally changing a repository.
-##' 
+##'
 ##' However, if a current package file is removed without \code{pruneRepo}, the
-##' PACKAGES, PACKAGES.gz and PACKAGES.rds file might be not up to date. To 
-##' ensure the correct information is available in these indices, run 
+##' PACKAGES, PACKAGES.gz and PACKAGES.rds file might be not up to date. To
+##' ensure the correct information is available in these indices, run
 ##' \code{updateRepo}.
 ##'
 ##' These functions are still undergoing development and polish and may
 ##' change in subsequent versions.
-##' 
+##'
 ##' @name pruneRepo
 ##' @title Prune repository from older copies of packages
 ##' @param repopath Character variable with the path to the repo;
 ##'  defaults to the value of the \dQuote{dratRepo} option with
 ##'  \dQuote{"~/git/drat"} as fallback
 ##' @param type Character variable for the type of repository, so far
-##'  \dQuote{source}, \dQuote{binary}, \dQuote{win.binary}, \dQuote{mac.binary}, 
-##'  \dQuote{mac.binary.mavericks}, \dQuote{mac.binary.el-capitan} or 
-##'  \dQuote{both}
+##'  \dQuote{source}, \dQuote{binary}, \dQuote{win.binary}, \dQuote{mac.binary},
+##'  \dQuote{mac.binary.mavericks}, \dQuote{mac.binary.el-capitan},
+##'  \dQuote{mac.binary.big-sur-arm64}, or \dQuote{both}
 ##' @param pkg Optional character variable specifying a package name,
 ##'  whose older versions should be pruned. If missing (the
 ##'  default), pruning is performed on all packages.
-##' @param version R version information in the format \code{X.Y} or 
-##'   \code{X.Y.Z}. Only used, if pruning binary packages. 
+##' @param version R version information in the format \code{X.Y} or
+##'   \code{X.Y.Z}. Only used, if pruning binary packages.
 ##'   (default: \code{version = getRversion()}). If \code{version = NA}, all
 ##'   available R versions will be used. If \code{version = NULL}, this defaults
 ##'   to \code{getRversion()}.
@@ -41,12 +41,12 @@
 ##'  different from (logical) \sQuote{FALSE} and equal to character
 ##'  \dQuote{git} files are removed via \code{git rm} else via a
 ##'  straight file deletion.
-##' @param ... For \code{updateRepo} a catch-all collection of parameters. 
-##'   Arguments passed to \code{update_PACKAGES} currently include 
-##'   \code{latestOnly}, for which the default value is set here to \code{FALSE}. 
-##'   See \code{\link{update_PACKAGES}}. Please note that this has an effect 
-##'   for \code{update_PACKAGES} only, if new packages are found, e.g. manually  
-##'   added. 
+##' @param ... For \code{updateRepo} a catch-all collection of parameters.
+##'   Arguments passed to \code{update_PACKAGES} currently include
+##'   \code{latestOnly}, for which the default value is set here to \code{FALSE}.
+##'   See \code{\link{update_PACKAGES}}. Please note that this has an effect
+##'   for \code{update_PACKAGES} only, if new packages are found, e.g. manually
+##'   added.
 ##' @return A data frame describing the repository is returned
 ##'  containing columns with columns \dQuote{file},
 ##'  \dQuote{package} (just the name), \dQuote{version} and a
@@ -54,8 +54,8 @@
 ##'  be removed.
 ##' @author Dirk Eddelbuettel
 getRepoInfo <- function(repopath = getOption("dratRepo", "~/git/drat"),
-                        type = c("source", "binary", "mac.binary", "mac.binary.el-capitan",
-                                 "mac.binary.mavericks", "win.binary", "both"), 
+                        type = c("source", "binary", "mac.binary", "mac.binary.big-sur-arm64", "mac.binary.el-capitan",
+                                 "mac.binary.mavericks", "win.binary", "both"),
                         pkg,
                         version = getRversion(),
                         location = getOption("dratBranch", "gh-pages")
@@ -84,8 +84,8 @@ getRepoInfo <- function(repopath = getOption("dratRepo", "~/git/drat"),
 
 .get_file_extension_from_package_type <- function(type){
     ##ext <- "_.*\\.tar\\..*$"            # with a nod to src/library/tools/packages.R
-    # ext <- "\\.tar\\..*$"            
-    
+    # ext <- "\\.tar\\..*$"
+
     ## type == "both" is not supported
     ext <- if (type == "source") {
         "\\.tar\\..*$"
@@ -104,40 +104,40 @@ getRepoInfo <- function(repopath = getOption("dratRepo", "~/git/drat"),
     if(length(files) == 0L){
         return(data.frame())
     }
-    
+
     R_version <- t
     if(t != "source"){
         R_version <- regmatches(rd,regexpr(DRAT_VERSION_REGEX, rd))
     }
-    
+
     ## subst. out the extension
     noextfiles <- gsub(e, "", files)
     noextfiles <- do.call(rbind, strsplit(noextfiles, "_", fixed = TRUE))
-    
+
     ## package names to the left
     # pkgs <- sapply(strsplit(files, "_", fixed=TRUE), "[", 1L)
     pkgs <- noextfiles[, 1L]
-    
+
     ## versions is then the remainder to the right -- FIXME for something better
     # verstxt <- gsub("[a-zA-Z0-9\\.]*_", "", noextfiles)
     verstxt <- noextfiles[, 2L]
-    
-    
+
+
     ## parse into proper version objects -- thanks, base R!
     vers <- package_version(verstxt)
-    
-    df <- data.frame(file = files, package = pkgs, version = vers, 
+
+    df <- data.frame(file = files, package = pkgs, version = vers,
                      type = t, contrib.url = rd,
                      stringsAsFactors = FALSE)
-    
+
     df <- df[order(df$package, df$version, decreasing = TRUE),]
     df$newest <- !duplicated(df$package)
-    
+
     df <- df[order(df$package, df$version, decreasing = FALSE),]
     if (!is.null(pkg)) {
         df <- df[df$package %in% pkg,]
     }
-    
+
     ## example output below plus additional type column
     ## R> df
     ##                      file   package  version newest
@@ -156,8 +156,8 @@ getRepoInfo <- function(repopath = getOption("dratRepo", "~/git/drat"),
 
 ##' @rdname pruneRepo
 pruneRepo <- function(repopath = getOption("dratRepo", "~/git/drat"),
-                      type = c("source", "binary", "mac.binary", "mac.binary.el-capitan",
-                               "mac.binary.mavericks", "win.binary", "both"), 
+                      type = c("source", "binary", "mac.binary", "mac.binary.big-sur-arm64", "mac.binary.el-capitan",
+                               "mac.binary.mavericks", "win.binary", "both"),
                       pkg,
                       version = getRversion(),
                       remove = FALSE,
@@ -201,8 +201,8 @@ pruneRepo <- function(repopath = getOption("dratRepo", "~/git/drat"),
 
 ##' @rdname pruneRepo
 pruneRepoForAllRversions <- function(repopath = getOption("dratRepo", "~/git/drat"),
-                                     type = c("source", "mac.binary", "mac.binary.el-capitan",
-                                              "mac.binary.mavericks", "win.binary", "both"), 
+                                     type = c("source", "mac.binary", "mac.binary.big-sur-arm64", "mac.binary.el-capitan",
+                                              "mac.binary.mavericks", "win.binary", "both"),
                                      pkg,
                                      remove = FALSE){
     pruneRepo(repopath = repopath, type = type, pkg = pkg, version = NA,
@@ -211,7 +211,7 @@ pruneRepoForAllRversions <- function(repopath = getOption("dratRepo", "~/git/dra
 
 ##' @rdname pruneRepo
 updateRepo <- function(repopath = getOption("dratRepo", "~/git/drat"),
-                       type = c("source", "mac.binary", "mac.binary.el-capitan",
+                       type = c("source", "mac.binary", "mac.binary.big-sur-arm64", "mac.binary.el-capitan",
                                 "mac.binary.mavericks", "win.binary", "both"),
                        version = NA,
                        ... ){

--- a/man/archivePackages.Rd
+++ b/man/archivePackages.Rd
@@ -7,16 +7,16 @@
 \usage{
 archivePackages(
   repopath = getOption("dratRepo", "~/git/drat"),
-  type = c("source", "binary", "mac.binary", "mac.binary.el-capitan",
-    "mac.binary.mavericks", "win.binary", "both"),
+  type = c("source", "binary", "mac.binary", "mac.binary.big-sur-arm64",
+    "mac.binary.el-capitan", "mac.binary.mavericks", "win.binary", "both"),
   pkg,
   version = getRversion()
 )
 
 archivePackagesForAllRversions(
   repopath = getOption("dratRepo", "~/git/drat"),
-  type = c("source", "binary", "mac.binary", "mac.binary.el-capitan",
-    "mac.binary.mavericks", "win.binary", "both"),
+  type = c("source", "binary", "mac.binary", "mac.binary.big-sur-arm64",
+    "mac.binary.el-capitan", "mac.binary.mavericks", "win.binary", "both"),
   pkg
 )
 }
@@ -26,22 +26,23 @@ defaults to the value of the \dQuote{dratRepo} option with
 \dQuote{"~/git/drat"} as fallback}
 
 \item{type}{Character variable for the type of repository, so far
-\dQuote{source}, \dQuote{binary}, \dQuote{win.binary}, \dQuote{mac.binary}, 
-\dQuote{mac.binary.mavericks}, \dQuote{mac.binary.el-capitan} or 
+\dQuote{source}, \dQuote{binary}, \dQuote{win.binary}, \dQuote{mac.binary},
+\dQuote{mac.binary.big-sur-arm64},
+\dQuote{mac.binary.mavericks}, \dQuote{mac.binary.el-capitan} or
 \dQuote{both}}
 
 \item{pkg}{Optional character variable specifying a package name(s), whose
-older versions should be archived. If missing (the default), archiving is 
+older versions should be archived. If missing (the default), archiving is
 performed on all packages.}
 
-\item{version}{R version information in the format \code{X.Y} or 
+\item{version}{R version information in the format \code{X.Y} or
 \code{X.Y.Z}. Only used, if archiving binary packages.
 (default: \code{version = getRversion()}). If \code{version = NA}, all
 available R versions will be used. If \code{version = NULL}, this defaults
 to \code{getRversion()}.}
 }
 \description{
-The function moves older versions of packages into a CRAN-style 
+The function moves older versions of packages into a CRAN-style
 archive folder.
 }
 \details{

--- a/man/pruneRepo.Rd
+++ b/man/pruneRepo.Rd
@@ -9,8 +9,8 @@
 \usage{
 getRepoInfo(
   repopath = getOption("dratRepo", "~/git/drat"),
-  type = c("source", "binary", "mac.binary", "mac.binary.el-capitan",
-    "mac.binary.mavericks", "win.binary", "both"),
+  type = c("source", "binary", "mac.binary", "mac.binary.big-sur-arm64",
+    "mac.binary.el-capitan", "mac.binary.mavericks", "win.binary", "both"),
   pkg,
   version = getRversion(),
   location = getOption("dratBranch", "gh-pages")
@@ -18,8 +18,8 @@ getRepoInfo(
 
 pruneRepo(
   repopath = getOption("dratRepo", "~/git/drat"),
-  type = c("source", "binary", "mac.binary", "mac.binary.el-capitan",
-    "mac.binary.mavericks", "win.binary", "both"),
+  type = c("source", "binary", "mac.binary", "mac.binary.big-sur-arm64",
+    "mac.binary.el-capitan", "mac.binary.mavericks", "win.binary", "both"),
   pkg,
   version = getRversion(),
   remove = FALSE,
@@ -28,16 +28,16 @@ pruneRepo(
 
 pruneRepoForAllRversions(
   repopath = getOption("dratRepo", "~/git/drat"),
-  type = c("source", "mac.binary", "mac.binary.el-capitan", "mac.binary.mavericks",
-    "win.binary", "both"),
+  type = c("source", "mac.binary", "mac.binary.big-sur-arm64", "mac.binary.el-capitan",
+    "mac.binary.mavericks", "win.binary", "both"),
   pkg,
   remove = FALSE
 )
 
 updateRepo(
   repopath = getOption("dratRepo", "~/git/drat"),
-  type = c("source", "mac.binary", "mac.binary.el-capitan", "mac.binary.mavericks",
-    "win.binary", "both"),
+  type = c("source", "mac.binary", "mac.binary.big-sur-arm64", "mac.binary.el-capitan",
+    "mac.binary.mavericks", "win.binary", "both"),
   version = NA,
   ...
 )
@@ -48,16 +48,16 @@ defaults to the value of the \dQuote{dratRepo} option with
 \dQuote{"~/git/drat"} as fallback}
 
 \item{type}{Character variable for the type of repository, so far
-\dQuote{source}, \dQuote{binary}, \dQuote{win.binary}, \dQuote{mac.binary}, 
-\dQuote{mac.binary.mavericks}, \dQuote{mac.binary.el-capitan} or 
-\dQuote{both}}
+\dQuote{source}, \dQuote{binary}, \dQuote{win.binary}, \dQuote{mac.binary},
+\dQuote{mac.binary.mavericks}, \dQuote{mac.binary.el-capitan},
+\dQuote{mac.binary.big-sur-arm64}, or \dQuote{both}}
 
 \item{pkg}{Optional character variable specifying a package name,
 whose older versions should be pruned. If missing (the
 default), pruning is performed on all packages.}
 
-\item{version}{R version information in the format \code{X.Y} or 
-\code{X.Y.Z}. Only used, if pruning binary packages. 
+\item{version}{R version information in the format \code{X.Y} or
+\code{X.Y.Z}. Only used, if pruning binary packages.
 (default: \code{version = getRversion()}). If \code{version = NA}, all
 available R versions will be used. If \code{version = NULL}, this defaults
 to \code{getRversion()}.}
@@ -73,11 +73,11 @@ different from (logical) \sQuote{FALSE} and equal to character
 \dQuote{git} files are removed via \code{git rm} else via a
 straight file deletion.}
 
-\item{...}{For \code{updateRepo} a catch-all collection of parameters. 
-Arguments passed to \code{update_PACKAGES} currently include 
-\code{latestOnly}, for which the default value is set here to \code{FALSE}. 
-See \code{\link{update_PACKAGES}}. Please note that this has an effect 
-for \code{update_PACKAGES} only, if new packages are found, e.g. manually  
+\item{...}{For \code{updateRepo} a catch-all collection of parameters.
+Arguments passed to \code{update_PACKAGES} currently include
+\code{latestOnly}, for which the default value is set here to \code{FALSE}.
+See \code{\link{update_PACKAGES}}. Please note that this has an effect
+for \code{update_PACKAGES} only, if new packages are found, e.g. manually
 added.}
 }
 \value{
@@ -98,8 +98,8 @@ that package. Older versions are therefore effectively shadowed
 and can be removed without functionally changing a repository.
 
 However, if a current package file is removed without \code{pruneRepo}, the
-PACKAGES, PACKAGES.gz and PACKAGES.rds file might be not up to date. To 
-ensure the correct information is available in these indices, run 
+PACKAGES, PACKAGES.gz and PACKAGES.rds file might be not up to date. To
+ensure the correct information is available in these indices, run
 \code{updateRepo}.
 
 These functions are still undergoing development and polish and may

--- a/tests/testArmBinary.R
+++ b/tests/testArmBinary.R
@@ -21,7 +21,7 @@ if (!isWindows) {                             # this is the default case of a so
 
 if (isArm && isVersion41) {
     pkg <- system.file("extdata", "big-sur-arm64", "bin", "4.1", "bar_1.0.tgz", package="drat")
-    drat::insertPackage(file = pkg, repodir = repodir)
+    drat::insertPackage(file = pkg, repodir = repodir, action = "prune")
 
     avpkg <- available.packages(repos=file.path("file:", docsdir))
 


### PR DESCRIPTION
re #134 

This PR simply adds `action = 'prune'` to the `insertPackage` call in `tests/testArmBinary.R`. That's where I was running into problems.

Not sure how much to invest in the tests because as far as I can tell, the tests only run on R 4.1.x and the CI is configured to use R 4.0.x. If I got that wrong let me know. However, these changes fixed the problems I was having inserting with action = prune.